### PR TITLE
removed appdir from fileName

### DIFF
--- a/opt/app.go
+++ b/opt/app.go
@@ -140,7 +140,7 @@ func (App) CreateBundle() {
 		}
 	}
 	uuidStr, _ := uuid.NewUUID()
-	fileName := rnDir + uuidStr.String() + ".zip"
+	fileName := uuidStr.String() + ".zip"
 	utils.Zip(rnDir+"build", fileName)
 	os.RemoveAll(rnDir + "build")
 	log.Println("Upload File...")


### PR DESCRIPTION
removed this because it creates a conflict between database records & actual bundle name
Ex: in the database, I can see the `download` column has only uuid with `.zip` extension but on the actual file name I can see the uuid with project folder name as a prefix 